### PR TITLE
Update abb_crb15000_5_95.srdf

### DIFF
--- a/config/abb_crb15000_5_95.srdf
+++ b/config/abb_crb15000_5_95.srdf
@@ -10,7 +10,7 @@
     <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
     <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
     <group name="manipulator">
-        <chain base_link="base_link" tip_link="link_6"/>
+        <chain base_link="base_link" tip_link="tool0"/>
     </group>
     <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
     <virtual_joint name="virtual_joint" type="fixed" parent_frame="world" child_link="base_link"/>


### PR DESCRIPTION
Dear Gonzalo,

ee_frame was set as link_6, though should be the tool0 frame. 
Would you be able to update this, as is relevant for correct moveit simulation.

Best, Gido